### PR TITLE
🐛 FIX: fix movie rendering

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ app.use(express.json());
 
 
 // movie container
-const movies = []
+const movies = [{movieTitle: "Captain Marvel", movieYear: "2019"}, {movieTitle: "Mohana", movieYear: "2018"}]
 
 
 app.get('/', (req, res) => {
@@ -40,11 +40,6 @@ app.get('/movies', (req, res) => {
     name: 'Ayu Adiati',
     movies: movies
 
-    // try with hard code
-		// movies: {
-    //   movieTitle: 'Moana',
-    //   movieYear: 2016
-    // }
 	});
 })
 

--- a/templates/views/movies.hbs
+++ b/templates/views/movies.hbs
@@ -11,22 +11,13 @@
   {{>header}}    
 
 
-    <ul class="movie-list">
-      {{#each movies}}
-      <li>{{@key}} {{ movieTitle }}</li>
-      <li>{{ movieYear }}</li>
-      <br>
-      {{/each}}
-    </ul>
-
-
-{{!-- <div class="movie-list">
+<div class="movie-list">
   {{#each movies}}
-  <p><strong>Title:</strong>{{ movies.movieTitle }}</p>
-  <p><strong>Year:</strong>{{movies.movieYear}}</p>
+  <p><strong>Title: </strong>{{ movieTitle }}</p>
+  <p><strong>Year: </strong>{{movieYear}}</p>
   <br>
   {{/each}}
-</div> --}}
+</div>
 
   <a href="/movies/new">Add movie</a>
   </div>


### PR DESCRIPTION
I've added two sample movies to the `movie` variable (array). The `movie` variable is a JavaScript array where each movie is an object with the keys `movieTitle` and `movieYear`.

I've changed the rendering for the movie view. Each "movies" in the handlebar templates is an object, so you don't need to render it as `{{ movie.movieYear }}`, etc., but as `{{ movieYear }}`.